### PR TITLE
Update log4j version for security patch to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.11.2</version>
+			<version>2.15.0</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Log4j has had a recent zero-day security exploit:
https://blogs.juniper.net/en-us/security/apache-log4j-vulnerability-cve-2021-44228-raises-widespread-concerns

This bump to fix the issue can be explained here:
https://www.springcloud.io/post/2021-12/log4j2-vulnerability-and-spring-boot/#maven